### PR TITLE
Fix PHP 8 compatibility: rename Error class and restore server/index.php loader

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -1,1 +1,2 @@
-mal.php
+<?php
+require __DIR__ . '/mal.php';

--- a/server/mal.php
+++ b/server/mal.php
@@ -43,7 +43,7 @@ if (php_sapi_name() == "cli") {
 
 
 // Errors/Exceptions
-class Error extends Exception {
+class MalError extends Exception {
     public $obj = null;
     public function __construct($obj) {
         parent::__construct("Mal Error", 0, null);
@@ -542,7 +542,7 @@ class Env {
 
 
 // Error/Exception functions
-function mal_throw($obj) { throw new Error($obj); }
+function mal_throw($obj) { throw new MalError($obj); }
 
 
 // String functions


### PR DESCRIPTION
This PR fixes two issues for PHP 8:
- Renames class Error → class MalError to avoid conflict.
- Corrects server/index.php to require mal.php.